### PR TITLE
Release v1.0.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.ricknout.rugbyranker"
         minSdkVersion min_sdk_version
         targetSdkVersion target_sdk_version
-        versionCode 1090
-        versionName "1.0.9"
+        versionCode 1091
+        versionName "1.0.10"
         setProperty("archivesBaseName", applicationId + "-v" + versionName)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Whoops, should have used the last integer for minor versions so that this could be `versionCode 1010`. Will do for v1.1.0 onwards.